### PR TITLE
Fix haddock markup

### DIFF
--- a/src/Reflex/Potato/Helpers.hs
+++ b/src/Reflex/Potato/Helpers.hs
@@ -265,7 +265,7 @@ sequenceEvents ev1 ev2 = mdo
         -- if ev1 does not trigger, delay does not trigger and this gives ev2
         -- if ev1 did trigger, and ev2 did not, this gives ev2
         -- if ev1 and ev2 both triggered, this gives previous value of evl2
-        -- * note that it's possible for ev1 or ev2 to trigger in the second frame for outside reasons
+        -- note that it's possible for ev1 or ev2 to trigger in the second frame for outside reasons
         -- if this is the case, you really should not use this function
         return $ leftmost [delayed, difference ev2 ev1]
   (ev2Delayed, redo) <- runWithReplace


### PR DESCRIPTION
Fixes the following error:

```
Running Haddock on library for reflex-potatoes-0.1.0.0..
Warning: --source-* options are ignored when --hyperlinked-source is enabled.
Haddock coverage:

src/Reflex/Potato/Helpers.hs:268:9: error:
    parse error on input ‘-- * note that it's possible for ev1 or ev2 to trigger in the second frame for outside reasons’
    |
268 |         -- * note that it's possible for ev1 or ev2 to trigger in the second frame for outside reasons
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```